### PR TITLE
Material hover effect and Theme colors as defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+* Add optional hover color style property
+* Add more left side menu items to example
+
 ## 0.1.3
 * Add simple example
 * Add go_router example

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,7 +75,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.3"
+    version: "0.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/item/side_menu_item_tile.dart
+++ b/lib/src/item/side_menu_item_tile.dart
@@ -132,7 +132,7 @@ class _SideMenuItemTileState extends State<SideMenuItemTile> {
     return AutoSizeText(
       widget.data.title!,
       style: titleStyle?.copyWith(
-        color: _isHovering ? widget.data.hoverColor : widget.data.isSelected ? widget.data.selectedColor : widget.data.unSelectedColor,
+        color: widget.data.isSelected ? widget.data.selectedColor : widget.data.unSelectedColor,
       ),
       maxLines: 1,
       overflow: TextOverflow.ellipsis,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_side_menu
 description: Flutter's full customizable side menu has been used as a directory for Related Pages, Navigation Items, Filter side and more
-version: 0.1.3
+version: 0.2.0
 homepage: https://github.com/resfandiari/flutter_side_menu
 
 environment:


### PR DESCRIPTION
This PR tries to sync SideMenu behaviour with that of default Material components by:
- implementing hover effect using Material and InkWell widgets default behaviour
- using default Material Theme colors and border radius on Side Menu and its items if those colours are not set manually