### PR TITLE
Possibility to add new Icons and TextStyle when selected.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,7 @@ class _MyAppState extends State<MyApp> {
             SideMenu(
               controller: _controller,
               backgroundColor: Colors.blueGrey,
+              mode: SideMenuMode.open,
               builder: (data) {
                 return SideMenuData(
                   header: const Text('Header'),
@@ -40,6 +41,7 @@ class _MyAppState extends State<MyApp> {
                       hoverColor: Colors.blue,
                       titleStyle: const TextStyle(color: Colors.white),
                       icon: const Icon(Icons.home),
+                      // selectedIcon: const Icon(Icons.abc),
                       badgeContent: const Text(
                         '23',
                         style: TextStyle(
@@ -52,19 +54,24 @@ class _MyAppState extends State<MyApp> {
                       isSelected: true,
                       onTap: () {},
                       title: 'Item 2',
+                      selectedTitleStyle:
+                          const TextStyle(fontWeight: FontWeight.bold),
                       icon: const Icon(Icons.table_bar),
+                      selectedIcon: const Icon(Icons.abc),
                     ),
                     SideMenuItemDataTile(
                       isSelected: false,
                       onTap: () {},
                       title: 'Item 3',
                       icon: const Icon(Icons.play_arrow),
+                      // selectedIcon: const Icon(Icons.abc),
                     ),
                     SideMenuItemDataTile(
                       isSelected: false,
                       onTap: () {},
                       title: 'Item 4',
                       icon: const Icon(Icons.car_crash),
+                      // selectedIcon: const Icon(Icons.abc),
                     ),
                   ],
                   footer: const Text('Footer'),

--- a/lib/src/data/side_menu_item_data.dart
+++ b/lib/src/data/side_menu_item_data.dart
@@ -13,6 +13,7 @@ class SideMenuItemDataTile extends SideMenuItemData {
     this.icon,
     this.title,
     this.titleStyle,
+    this.selectedTitleStyle,
     this.tooltip,
     this.badgeContent,
     this.hasSelectedLine = true,
@@ -24,6 +25,7 @@ class SideMenuItemDataTile extends SideMenuItemData {
     this.margin = Constants.itemMargin,
     this.borderRadius,
     this.selectedColor,
+    this.selectedIcon,
     this.unSelectedColor,
     this.highlightSelectedColor,
     this.hoverColor,
@@ -38,11 +40,13 @@ class SideMenuItemDataTile extends SideMenuItemData {
   final Size selectedLineSize;
   final String? title;
   final TextStyle? titleStyle;
+  final TextStyle? selectedTitleStyle;
   final String? tooltip;
   final Widget? badgeContent;
   final BadgePosition? badgePosition;
   final BadgeStyle? badgeStyle;
   final Widget? icon;
+  final Widget? selectedIcon;
   final double itemHeight;
   final EdgeInsetsDirectional margin;
   final BorderRadiusGeometry? borderRadius;
@@ -56,11 +60,13 @@ class SideMenuItemDataTitle extends SideMenuItemData {
   const SideMenuItemDataTitle({
     required this.title,
     this.titleStyle,
+    this.selectedTitleStyle,
     this.padding = Constants.itemMargin,
   }) : super();
 
   final String title;
   final TextStyle? titleStyle;
+  final TextStyle? selectedTitleStyle;
   final EdgeInsetsDirectional padding;
 }
 

--- a/lib/src/item/side_menu_item_tile.dart
+++ b/lib/src/item/side_menu_item_tile.dart
@@ -147,7 +147,6 @@ class _SideMenuItemTileState extends State<SideMenuItemTile> {
               data: Theme.of(context)
                   .iconTheme
                   .copyWith(color: getSelectedColor()),
-              // child: widget.data.icon!,
               child: getSelectedIcon()!,
             ),
           )

--- a/lib/src/item/side_menu_item_tile.dart
+++ b/lib/src/item/side_menu_item_tile.dart
@@ -28,7 +28,8 @@ class _SideMenuItemTileState extends State<SideMenuItemTile> {
       decoration: ShapeDecoration(
         shape: shape(context),
         color: widget.data.isSelected
-            ? widget.data.highlightSelectedColor ?? Theme.of(context).colorScheme.secondaryContainer
+            ? widget.data.highlightSelectedColor ??
+                Theme.of(context).colorScheme.secondaryContainer
             : null,
       ),
       child: Material(
@@ -54,8 +55,16 @@ class _SideMenuItemTileState extends State<SideMenuItemTile> {
 
   Color getSelectedColor() {
     return widget.data.isSelected
-        ? widget.data.selectedColor ?? Theme.of(context).colorScheme.onSecondaryContainer
-        : widget.data.unSelectedColor ?? Theme.of(context).colorScheme.onSurfaceVariant;
+        ? widget.data.selectedColor ??
+            Theme.of(context).colorScheme.onSecondaryContainer
+        : widget.data.unSelectedColor ??
+            Theme.of(context).colorScheme.onSurfaceVariant;
+  }
+
+  Widget? getSelectedIcon() {
+    return widget.data.isSelected && widget.data.selectedIcon != null
+        ? widget.data.selectedIcon
+        : widget.data.icon;
   }
 
   Widget _createView({
@@ -69,7 +78,9 @@ class _SideMenuItemTileState extends State<SideMenuItemTile> {
       ),
     );
 
-    return widget.data.isSelected && widget.data.hasSelectedLine ? _hasSelectedLine(child: content) : content;
+    return widget.data.isSelected && widget.data.hasSelectedLine
+        ? _hasSelectedLine(child: content)
+        : content;
   }
 
   Widget _hasTooltip({
@@ -133,8 +144,11 @@ class _SideMenuItemTileState extends State<SideMenuItemTile> {
             width: widget.minWidth - widget.data.margin.horizontal,
             height: double.maxFinite,
             child: IconTheme(
-              data: Theme.of(context).iconTheme.copyWith(color: getSelectedColor()),
-              child: widget.data.icon!,
+              data: Theme.of(context)
+                  .iconTheme
+                  .copyWith(color: getSelectedColor()),
+              // child: widget.data.icon!,
+              child: getSelectedIcon()!,
             ),
           )
         : const SizedBox.shrink();
@@ -143,10 +157,15 @@ class _SideMenuItemTileState extends State<SideMenuItemTile> {
   Widget _title({
     required BuildContext context,
   }) {
-    final TextStyle? titleStyle = widget.data.titleStyle ?? Theme.of(context).textTheme.bodyLarge;
+    final TextStyle? titleStyle =
+        widget.data.titleStyle ?? Theme.of(context).textTheme.bodyLarge;
+    final TextStyle? selectedTitleStyle =
+        widget.data.selectedTitleStyle ?? Theme.of(context).textTheme.bodyLarge;
     return AutoSizeText(
       widget.data.title!,
-      style: titleStyle?.copyWith(color: getSelectedColor()),
+      style: widget.data.isSelected
+          ? selectedTitleStyle?.copyWith(color: getSelectedColor())
+          : titleStyle?.copyWith(color: getSelectedColor()),
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
     );


### PR DESCRIPTION
I created this pull to add the feature of adding new icons when the menu is selected, if the `selectedIcon` is `null`, the default icon will be kept, so is the behavior of the `selectedTitleStyle`.

```
SideMenuItemDataTile(
    isSelected: true,
    margin: EdgeInsetsDirectional.zero,
    borderRadius: const BorderRadius.only(
        topRight: Radius.circular(15),
        bottomRight: Radius.circular(15)),
    highlightSelectedColor: Colors.transparent,
    onTap: () {},
    title: 'Home',
    icon: const Icon(FontAwesomeIcons.lightGrid2),
    selectedIcon: const Icon(FontAwesomeIcons.grid2),
    selectedTitleStyle: const TextStyle(
        fontWeight: FontWeight.bold, fontSize: 18),
  ),
```