### PR TITLE
Added support to alignment SideMenuItemDataTitle

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,8 +40,8 @@ class _MyAppState extends State<MyApp> {
                       title: 'Item 1',
                       hoverColor: Colors.blue,
                       titleStyle: const TextStyle(color: Colors.white),
-                      icon: const Icon(Icons.home),
-                      // selectedIcon: const Icon(Icons.abc),
+                      icon: const Icon(Icons.home_outlined),
+                      selectedIcon: const Icon(Icons.home),
                       badgeContent: const Text(
                         '23',
                         style: TextStyle(
@@ -56,22 +56,20 @@ class _MyAppState extends State<MyApp> {
                       title: 'Item 2',
                       selectedTitleStyle:
                           const TextStyle(fontWeight: FontWeight.bold),
-                      icon: const Icon(Icons.table_bar),
-                      selectedIcon: const Icon(Icons.abc),
+                      icon: const Icon(Icons.table_bar_outlined),
+                      selectedIcon: const Icon(Icons.table_bar),
                     ),
                     SideMenuItemDataTile(
                       isSelected: false,
                       onTap: () {},
                       title: 'Item 3',
                       icon: const Icon(Icons.play_arrow),
-                      // selectedIcon: const Icon(Icons.abc),
                     ),
                     SideMenuItemDataTile(
                       isSelected: false,
                       onTap: () {},
                       title: 'Item 4',
                       icon: const Icon(Icons.car_crash),
-                      // selectedIcon: const Icon(Icons.abc),
                     ),
                   ],
                   footer: const Text('Footer'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,6 +59,10 @@ class _MyAppState extends State<MyApp> {
                       icon: const Icon(Icons.table_bar_outlined),
                       selectedIcon: const Icon(Icons.table_bar),
                     ),
+                    const SideMenuItemDataTitle(
+                      title: 'Account',
+                      textAlign: TextAlign.center,
+                    ),
                     SideMenuItemDataTile(
                       isSelected: false,
                       onTap: () {},

--- a/lib/src/data/side_menu_item_data.dart
+++ b/lib/src/data/side_menu_item_data.dart
@@ -60,13 +60,11 @@ class SideMenuItemDataTitle extends SideMenuItemData {
   const SideMenuItemDataTitle({
     required this.title,
     this.titleStyle,
-    this.selectedTitleStyle,
     this.padding = Constants.itemMargin,
   }) : super();
 
   final String title;
   final TextStyle? titleStyle;
-  final TextStyle? selectedTitleStyle;
   final EdgeInsetsDirectional padding;
 }
 

--- a/lib/src/data/side_menu_item_data.dart
+++ b/lib/src/data/side_menu_item_data.dart
@@ -60,11 +60,13 @@ class SideMenuItemDataTitle extends SideMenuItemData {
   const SideMenuItemDataTitle({
     required this.title,
     this.titleStyle,
+    this.textAlign,
     this.padding = Constants.itemMargin,
   }) : super();
 
   final String title;
   final TextStyle? titleStyle;
+  final TextAlign? textAlign;
   final EdgeInsetsDirectional padding;
 }
 

--- a/lib/src/item/side_menu_item_title.dart
+++ b/lib/src/item/side_menu_item_title.dart
@@ -26,6 +26,7 @@ class SideMenuItemTitle extends StatelessWidget {
       data.title,
       style: titleStyle,
       maxLines: 1,
+      textAlign: data.textAlign,
       overflow: TextOverflow.ellipsis,
     );
   }


### PR DESCRIPTION
I made this PR to support alignment for the SideMenuItemDataTile in the following options: Left, Right, Center.

 **Center**:
![image](https://user-images.githubusercontent.com/113481056/233740756-6f1d31b6-e5a4-42a5-8c42-4cb70c74bc1d.png)

**Right**:
![image](https://user-images.githubusercontent.com/113481056/233740797-97eaf625-dac6-4408-b7f6-c28c7fe584bb.png)
